### PR TITLE
Add action card effect handlers and invoke by ID

### DIFF
--- a/flavor_clash/public/actionEffects.js
+++ b/flavor_clash/public/actionEffects.js
@@ -1,0 +1,13 @@
+// /public/actionEffects.js
+// Effect handlers for action cards
+
+export function swapHands(state, { dealHand }) {
+  state.discardPile.push(...state.hand);
+  state.hand = [];
+  dealHand();
+}
+
+export function superMultiplier(state) {
+  state.multiplier = 10;
+  state.multiplierTurns = 3;
+}


### PR DESCRIPTION
## Summary
- Add dedicated action effect module implementing `swapHands` and `superMultiplier`
- Route action cards through `playActionCard` mapping to appropriate handlers
- Apply active multiplier during scoring and track remaining turns

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acac0e13a883329e727a8ed607b80e