### PR TITLE
Fix undefined servedPlate in game logic

### DIFF
--- a/flavor_clash/public/game.js
+++ b/flavor_clash/public/game.js
@@ -261,11 +261,15 @@ async function servePlate() {
     alert('Afegeix almenys 2 cartes al plat per puntuar.');
     return;
   }
-  const forbiddenCount = state.plate.filter((c) => isCardForbidden(state.deckId, c.id)).length;
-  let delta = scoreCombination(state.plate) - forbiddenCount * 10;
-  const info = explainCombination(state.plate);
+  const servedPlate = [...state.plate];
+  const forbiddenCount = servedPlate.filter((c) =>
+    isCardForbidden(state.deckId, c.id)
+  ).length;
+  let delta = scoreCombination(servedPlate) - forbiddenCount * 10;
+  const info = explainCombination(servedPlate);
   state.score += delta;
   state.turn += 1;
+  verifyObjectives(servedPlate);
   state.discardPile.push(...servedPlate);
   state.plate = [];
   updateHUD();


### PR DESCRIPTION
## Summary
- clone current plate before scoring to avoid undefined variable
- validate objectives and discard served cards correctly

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acdce8a9c48332a82d72b45703cbe2